### PR TITLE
Added dynamic routes example

### DIFF
--- a/MyApp/nuxt.config.js
+++ b/MyApp/nuxt.config.js
@@ -2,7 +2,15 @@ module.exports = {
   mode: 'spa',
   srcDir: 'src',
   generate: {
-    dir: 'wwwroot'
+    dir: 'wwwroot',
+    /*
+    ** Generate dynamic routes for static file servers that 
+    *  don't provide a way to fallback to a default index.html page
+    */
+    routes: [
+      '/posts/1',
+      '/posts/2'
+    ]
   },
   plugins: [{ src: '~/plugins/nuxt-client-init.js', ssr: false }],
   modules: ["@nuxtjs/proxy"],

--- a/MyApp/src/layouts/default.vue
+++ b/MyApp/src/layouts/default.vue
@@ -17,6 +17,12 @@
                     <li class="nav-item">
                         <nuxt-link class="nav-link" to="/about">About</nuxt-link>
                     </li>
+                    <li class="nav-item">
+                        <nuxt-link class="nav-link" to="/posts/1">Post #1</nuxt-link>
+                    </li>
+                    <li class="nav-item">
+                        <nuxt-link class="nav-link" to="/posts/2">Post #2</nuxt-link>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/MyApp/src/pages/posts/_id.vue
+++ b/MyApp/src/pages/posts/_id.vue
@@ -1,0 +1,24 @@
+<template>
+  <section class="container">
+    <div>
+      <h1>Post</h1>
+
+      <h4 style="margin-top: 30px">ServiceStack Post #{{ id }}</h4>
+      
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  validate ({ params }) {
+    // Must be a number
+    return /^\d+$/.test(params.id)
+  },
+  computed: {
+    id: function () {
+      return this.$route.params.id
+    }
+  }
+}
+</script>


### PR DESCRIPTION
The generate.routes property config in nuxt.config.js is optional, but useful in certain cases if hosting on a static file server without 'spa' fallback route handling capabilities (i.e.: nuxt generate).